### PR TITLE
Enforce pages title consistency

### DIFF
--- a/src/routes/tags/[tag].svelte
+++ b/src/routes/tags/[tag].svelte
@@ -37,7 +37,8 @@
 	export let prettyTagName: string;
 	export let articles: WritingPreview[];
 
-	$: title = `Baptiste Devessier - Writing about ${prettyTagName}`;
+	$: formattedTag = prettyTagName ?? tag;
+	$: title = `Baptiste Devessier | Writing about ${formattedTag}`;
 	const description = 'Développeur Web Full Stack sur Paris';
 	$: canonical = `https://baptiste.devessier.fr/tags/${tag}/`;
 	const schemas = [];
@@ -61,7 +62,7 @@
 <Page class="pb-16" {title} {description} {canonical} {schemas} {facebook} {twitter}>
 	<BlogPostsList {articles}>
 		<svelte:fragment slot="title">
-			Writing about {prettyTagName ?? tag}
+			Writing about {formattedTag}
 		</svelte:fragment>
 
 		<svelte:fragment slot="empty">I have not started writing about this topic yet.</svelte:fragment>

--- a/src/routes/writing/index.svelte
+++ b/src/routes/writing/index.svelte
@@ -28,7 +28,7 @@
 
 	export let articles: WritingPreview[];
 
-	const title = 'Baptiste Devessier - Writing';
+	const title = 'Baptiste Devessier | Writing';
 	const description = 'Développeur Web Full Stack sur Paris';
 	const canonical = 'https://baptiste.devessier.fr/writing/';
 	const schemas = [];


### PR DESCRIPTION
Writing and tags pages used to have a dash instead of a pipe as the separator in their titles.