### PR TITLE
Migrate links prefetching and add prefetching to new links

### DIFF
--- a/src/lib/AppBadge.svelte
+++ b/src/lib/AppBadge.svelte
@@ -7,6 +7,7 @@
 
 <a
 	{href}
+	sveltekit:prefetch
 	class="border-gray-300 mb-2 border text-gray-600 bg-white hover:bg-gray-50 transition-colors duration-100 ease-out font-normal text-xs px-3 py-1 rounded-2xl flex-shrink-0 mx-1 {className}"
 >
 	<slot />

--- a/src/lib/BlogPostsList.svelte
+++ b/src/lib/BlogPostsList.svelte
@@ -32,7 +32,7 @@
 						{formattedDatetime}
 					</time>
 
-					<a href={`/writing/${slug}`} class="mt-2">
+					<a href={`/writing/${slug}`} sveltekit:prefetch class="mt-2">
 						<h2 class="text-2xl leading-8 font-semibold hover:underline">
 							{title}
 						</h2>

--- a/src/lib/Nav/Nav.svelte
+++ b/src/lib/Nav/Nav.svelte
@@ -61,7 +61,7 @@
 
 <nav class="py-6">
 	<div class="flex items-center justify-between">
-		<a href="/" rel="prefetch" class="text-2xl tracking-wider main-link-font">
+		<a href="/" sveltekit:prefetch class="text-2xl tracking-wider main-link-font">
 			<LogoIcon class="w-20 h-20" title="Accueil" />
 		</a>
 

--- a/src/lib/Nav/NavLink.svelte
+++ b/src/lib/Nav/NavLink.svelte
@@ -7,7 +7,7 @@
 	export { className as class };
 </script>
 
-<a {href} rel="prefetch" class:active-link={active} class={className} on:click>
+<a {href} sveltekit:prefetch class:active-link={active} class={className} on:click>
 	<slot />
 </a>
 

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -90,7 +90,7 @@
 			{#each communicationMeans as { href, title, icon }, index}
 				<li>
 					<a
-						rel="prefetch"
+						sveltekit:prefetch
 						{href}
 						class="block p-2 text-red-500 border border-gray-200
                         rounded-full {index < communicationMeans.length - 1 ? 'mr-2' : ''}"


### PR DESCRIPTION
We migrated all `rel="prefetch"` to `sveltekit:prefetch` and we added prefetching to blog links.

Closes #8 