### PR TITLE
Set SEO meta tags for articles

### DIFF
--- a/src/lib/BlogLayout.svelte
+++ b/src/lib/BlogLayout.svelte
@@ -9,13 +9,16 @@
 	export let datetime;
 	export let tags;
 
-	// TODO: to be defined
-	const canonical = 'https://baptiste.devessier.fr/';
+	$: sluggifiedTitle = slugify(title, {
+		lower: true
+	});
+
+	$: canonical = `https://baptiste.devessier.fr/writing/${sluggifiedTitle}/`;
 	const schemas = [];
-	const facebook = [
+	$: facebook = [
 		{
 			name: 'og:url',
-			content: 'https://baptiste.devessier.fr/'
+			content: canonical
 		},
 		{
 			name: 'og:title',


### PR DESCRIPTION
We will use the title of the article as the title of the page.
We use the sluggified title as the canonical URL of the page.

Closes #13 