### PR TITLE
Force trailing slashes

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -27,9 +27,9 @@
 			href="https://fonts.googleapis.com/css2?family=Comfortaa:wght@700&display=swap"
 		/>
 
-		<link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
-		<link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png" />
-		<link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png" />
+		<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+		<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+		<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
 
 		<!-- Facebook SEO meta tags -->
 		<meta property="og:site_name" content="baptiste.devessier.fr" />

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -3,6 +3,13 @@ import { v4 as uuid } from '@lukeed/uuid';
 import type { Handle } from '@sveltejs/kit';
 
 export const handle: Handle = async ({ request, resolve }) => {
+	// We activated `trailingSlash: 'always'` and we need to remove the trailing
+	// slash from the request path because SvelteKit would not find the endpoint otherwise.
+	// See https://kit.svelte.dev/docs#configuration-trailingslash.
+	if (request.path === '/feed.xml/') {
+		request.path = '/feed.xml';
+	}
+
 	const cookies = cookie.parse(request.headers.cookie || '');
 	request.locals.userid = cookies.userid || uuid();
 

--- a/src/lib/BlogLayout.svelte
+++ b/src/lib/BlogLayout.svelte
@@ -43,7 +43,7 @@
 	<div class="max-w-prose text-lg mx-auto">
 		<div class="flex items-center justify-center flex-wrap mb-2">
 			{#each formattedTags as { title, slug }}
-				<AppBadge href="/tags/{slug}">
+				<AppBadge href="/tags/{slug}/">
 					{title}
 				</AppBadge>
 			{/each}

--- a/src/lib/BlogPostsList.svelte
+++ b/src/lib/BlogPostsList.svelte
@@ -30,7 +30,7 @@
 						{formattedDatetime}
 					</time>
 
-					<a href={`/writing/${slug}`} sveltekit:prefetch class="mt-2">
+					<a href="/writing/{slug}/" sveltekit:prefetch class="mt-2">
 						<h2 class="text-2xl leading-8 font-semibold hover:underline">
 							{title}
 						</h2>
@@ -42,7 +42,7 @@
 
 					<div class="flex mt-4">
 						{#each tags as { title, slug }, index}
-							<AppBadge href="/tags/{slug}" class={index === 0 ? 'ml-0' : 'ml-2'}>
+							<AppBadge href="/tags/{slug}/" class={index === 0 ? 'ml-0' : 'ml-2'}>
 								{title}
 							</AppBadge>
 						{/each}

--- a/src/lib/Nav/Nav.svelte
+++ b/src/lib/Nav/Nav.svelte
@@ -12,27 +12,27 @@
 
 	const links = [
 		{
-			href: '/my-journey',
+			href: '/my-journey/',
 			text: 'My journey'
 		},
 		{
-			href: '/projects',
+			href: '/projects/',
 			text: 'Projects'
 		},
 		{
-			href: '/writing',
+			href: '/writing/',
 			text: 'Writing'
 		},
 		{
-			href: '/talks',
+			href: '/talks/',
 			text: 'Talks'
 		},
 		{
-			href: '/notes',
+			href: '/notes/',
 			text: 'Notes'
 		},
 		{
-			href: '/contact',
+			href: '/contact/',
 			text: 'Contact'
 		}
 	];

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -36,7 +36,7 @@
 			icon: GithubIcon
 		},
 		{
-			href: '/contact',
+			href: '/contact/',
 			external: false,
 			title: 'Contact me',
 			icon: MailIcon

--- a/src/routes/my-journey.svelte
+++ b/src/routes/my-journey.svelte
@@ -7,7 +7,7 @@
 	const title = 'Baptiste Devessier | My journey';
 	const description =
 		'My journey to become a Full Stack Web Developer specialized in JavaScript, TypeScript, Vue.js, Nuxt.js, TailwindCSS, Svelte, SvelteKit and Node.js';
-	const canonical = 'https://baptiste.devessier.fr/my-way/';
+	const canonical = 'https://baptiste.devessier.fr/my-journey/';
 	const schemas = [];
 	const facebook = [
 		{

--- a/src/routes/writing/create-state-machines-in-erlang.svx
+++ b/src/routes/writing/create-state-machines-in-erlang.svx
@@ -15,7 +15,7 @@ When in logged in state, user can log out; when in logged out state, user can lo
 
 These interactions are schematized below.
 
-![Schema of chat system with authentication states](../../../static/chat%20erlang%20system.png)
+![Schema of chat system with authentication states](/chat%20erlang%20system.png)
 
 Let's implement this state machine in Erlang without any library, by making great use of pattern matching.
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -67,7 +67,8 @@ const config = {
 			enabled: true,
 			onError: 'continue',
 			entries: ['*']
-		}
+		},
+		trailingSlash: 'always'
 	}
 };
 


### PR DESCRIPTION
We want to be consistent and use trailing slashes everywhere. This will reduce duplications in Plausible between pages first viewed (with a trailing slash now) and pages visited with client-side routing (without trailing slash now).

We also fix some issues with favicons and an image of an article.