### PR TITLE
Fix issue with dates being interpreted differently between the server and the client

### DIFF
--- a/src/lib/format-date.ts
+++ b/src/lib/format-date.ts
@@ -4,6 +4,7 @@ export function formatDate(datetime: string): string {
 	return new Intl.DateTimeFormat('en-US', {
 		day: 'numeric',
 		month: 'long',
-		year: 'numeric'
+		year: 'numeric',
+		timeZone: 'UTC'
 	}).format(date);
 }


### PR DESCRIPTION
We always format dates according to UTC timezone.

Closes https://github.com/Devessier/portfolio/issues/52